### PR TITLE
Add PR and CI Github Actions Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on: 
+  push:
+    branches:
+      - master
 
 jobs:
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code & submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: latest
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build Package
+        run: pnpm run build
+
+      - name: "Publish to NPM"
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: latest
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build Package
+        run: pnpm build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,3 +19,19 @@ jobs:
 
       - name: Build Package
         run: pnpm build
+
+      - name: Check if version has been updated
+        id: check
+        uses: EndBug/version-check@v2
+        with:
+          diff-search: true
+
+      - name: Log when changed
+        if: steps.check.outputs.changed == 'true'
+        run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+      
+      - name: Log when unchanged
+        if: steps.check.outputs.changed == 'false'
+        run: |
+          'echo "No version change :/"'
+          exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,17 +21,17 @@ jobs:
         run: pnpm build
 
       - name: Check if version has been updated
-        id: check
+        id: check-version-changed
         uses: EndBug/version-check@v2
         with:
           diff-search: true
 
       - name: Log when changed
-        if: steps.check.outputs.changed == 'true'
-        run: 'echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+        if: steps.check-version-changed.outputs.changed == 'true'
+        run: echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"
       
       - name: Log when unchanged
-        if: steps.check.outputs.changed == 'false'
+        if: steps.check-version-changed.outputs.changed == 'false'
         run: |
-          'echo "No version change :/"'
+          echo "No version change. Please update the package version in package.json"
           exit 1


### PR DESCRIPTION
Adds the CI and PR workflows from meshtastic/js.

Additionally adds a check to the workflow to ensure the `package.json` version has been bumped in the PR workflow.

Requires the `NPM_TOKEN` used to publish to the NPM registry to be added as an Organization secret, or added to the secrets for this repository.