### PR TITLE
Add new payload variant decodings

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -21,6 +21,10 @@ const nodeInit: NodeInitializer = (RED): void => {
             let data: unknown;
 
             switch (decoded.packet.payloadVariant.value.portnum) {
+
+              case Protobuf.PortNum.UNKNOWN_APP:
+                break;
+
               case Protobuf.PortNum.TEXT_MESSAGE_APP:
                 data = new TextDecoder().decode(payload);
                 break;
@@ -52,6 +56,12 @@ const nodeInit: NodeInitializer = (RED): void => {
                 data = Protobuf.Waypoint.fromBinary(payload);
                 break;
 
+              case Protobuf.PortNum.AUDIO_APP:
+                break;
+
+              case Protobuf.PortNum.DETECTION_SENSOR_APP:
+                break;
+
               case Protobuf.PortNum.REPLY_APP:
                 break;
 
@@ -69,6 +79,18 @@ const nodeInit: NodeInitializer = (RED): void => {
 
               case Protobuf.PortNum.TELEMETRY_APP:
                 data = Protobuf.Telemetry.fromBinary(payload);
+                break;
+
+              case Protobuf.PortNum.ZPS_APP:
+                break;
+
+              case Protobuf.PortNum.SIMULATOR_APP:
+                break;
+
+              case Protobuf.PortNum.TRACEROUTE_APP:
+                break;
+
+              case Protobuf.PortNum.NEIGHBORINFO_APP:
                 break;
 
               case Protobuf.PortNum.PRIVATE_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -67,6 +67,7 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.REPLY_APP:
+                data = new TextDecoder('ascii').decode(payload)
                 break;
 
               case Protobuf.PortNum.IP_TUNNEL_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -50,6 +50,9 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.TEXT_MESSAGE_COMPRESSED_APP:
+                // should never get here
+                // should be decompressed by the firmware to a TEXT_MESSAGE_APP packet
+                throw new Error("Received a TEXT_MESSAGE_COMPRESSED_APP message.\nPlease open an issue on Github as this should never happen");
                 break;
 
               case Protobuf.PortNum.WAYPOINT_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -81,6 +81,7 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.RANGE_TEST_APP:
+                data = new TextDecoder('ascii').decode(payload)
                 break;
 
               case Protobuf.PortNum.TELEMETRY_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -63,6 +63,7 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.DETECTION_SENSOR_APP:
+                data = new TextDecoder().decode(payload);
                 break;
 
               case Protobuf.PortNum.REPLY_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -98,6 +98,7 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.NEIGHBORINFO_APP:
+                data = Protobuf.NeighborInfo.fromBinary(payload);
                 break;
 
               case Protobuf.PortNum.PRIVATE_APP:

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -77,6 +77,7 @@ const nodeInit: NodeInitializer = (RED): void => {
                 break;
 
               case Protobuf.PortNum.STORE_FORWARD_APP:
+                data = Protobuf.StoreAndForward.fromBinary(payload);
                 break;
 
               case Protobuf.PortNum.RANGE_TEST_APP:


### PR DESCRIPTION
Adds the following payload decodings:
- [DETECTION_SENSOR_APP](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto#L102-L106)
- [REPLY_APP](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto#L108-L113)
- [STORE_FORWARD_APP](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto#L131-L136)
- [RANGE_TEST_APP](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto#L138-L143)
- [NEIGHBORINFO_APP](https://github.com/meshtastic/protobufs/blob/master/meshtastic/portnums.proto#L176-L180)