### PR TITLE
Fix PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Log when changed
         if: steps.check-version-changed.outputs.changed == 'true'
-        run: echo "Version change found in commit ${{ steps.check.outputs.commit }}! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"
+        run: echo "Version change found in commit ${{ steps.check-version-changed.outputs.commit }}! New version is ${{ steps.check-version-changed.outputs.version }} (${{ steps.check-version-changed.outputs.type }})"
       
       - name: Log when unchanged
         if: steps.check-version-changed.outputs.changed == 'false'


### PR DESCRIPTION
The step name for the outputs was incorrect, and Github's validation was throwing an error on the use of `:` in the echo