### PR TITLE
Add debug logging and invert instanceOf check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshtastic/node-red-contrib-meshtastic",
-  "version": "2.2.18-0",
+  "version": "2.2.18-1",
   "description": "Meshtastic protobuf converter for NodeRED",
   "keywords": [
     "node-red"


### PR DESCRIPTION
With Telemetry moving out of `Mesh` the `instanceOf` check was no longer parsing Telemetry packets. By inverting the check we assume that if the decoder is not `null` nor a `TextDecoder` that it is a Protobuf message and attempt to decode.

Additionally adds some debug logs and fixes some Biome checks.